### PR TITLE
Add order details to Stripe request & fix localization

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -74,7 +74,14 @@ jQuery(function($) {
 		var tokenArgs = {
 			number: cardNumber, 
 			exp_month: expiryDate.month,
-			exp_year: expiryDate.year
+			exp_year: expiryDate.year,
+			name: $('#billing_first_name').val() + ' ' + $('#billing_last_name').val(),
+			address_line1: $('#billing_address_1').val(),
+			address_line2: $('#billing_address_2').val(),
+			address_city: $('#billing_city').val(),
+			address_state: $('#billing_state').val(),
+			address_zip: $('#billing_postcode').val(),
+			address_country: $('#billing_country').val()
 		};
 		if (cvc.length > 0)
 			tokenArgs.cvc = cvc;

--- a/i18n/languages/mg-wc-stripe-it_IT.po
+++ b/i18n/languages/mg-wc-stripe-it_IT.po
@@ -103,7 +103,7 @@ msgid "%s payment completed with charge id '%s'"
 msgstr "%s pagamento completato con charge id '%s'"
 
 #: build/includes/gateway.php:233 includes/gateway.php:242
-msgid "Stripe error: "
+msgid "Payment error: "
 msgstr "Errore Stripe"
 
 #: build/includes/gateway.php:240 includes/gateway.php:249

--- a/i18n/languages/mg-wc-stripe.pot
+++ b/i18n/languages/mg-wc-stripe.pot
@@ -94,7 +94,7 @@ msgid "%s payment completed with charge id '%s'"
 msgstr ""
 
 #: build/includes/gateway.php:233 includes/gateway.php:242
-msgid "Stripe error: "
+msgid "Payment error: "
 msgstr ""
 
 #: build/includes/gateway.php:240 includes/gateway.php:249

--- a/includes/gateway.php
+++ b/includes/gateway.php
@@ -239,7 +239,7 @@ class mg_Gateway_Stripe extends WC_Payment_Gateway {
 			// Build error message string
 			$body = $e->getJsonBody();
 			$error  = $body['error'];
-			$err_msg = __('Stripe error: ', $this->cfg['text_domain']) . $error['message'];
+			$err_msg = __('Payment error: ', $this->cfg['text_domain']) . $error['message'];
 			
 			// Deliver error message...
 			

--- a/includes/gateway.php
+++ b/includes/gateway.php
@@ -208,7 +208,7 @@ class mg_Gateway_Stripe extends WC_Payment_Gateway {
 	
 	public function process_payment($order_id) {
 		$payment_completed = false;
-		
+
 		try {
 			$token = isset($_POST['stripe_token']) ? wc_clean($_POST['stripe_token'] ) : '';
 		
@@ -293,7 +293,7 @@ class mg_Gateway_Stripe extends WC_Payment_Gateway {
 			'currency' => strtolower($currency),
 			'amount' => $amount,
 			'card' => $token,
-			'description' => sprintf(__('%s - Order %s', $this->cfg['text_domain']), esc_html(get_bloginfo('name')), $order->get_order_number())
+			'description' => sprintf(__('%s - Order %s', $this->cfg['text_domain']), esc_html(get_bloginfo('name')), $order->get_order_number()),
 		));
 		
 		return $charge;

--- a/includes/gateway.php
+++ b/includes/gateway.php
@@ -215,8 +215,8 @@ class mg_Gateway_Stripe extends WC_Payment_Gateway {
 			if (empty($token))
 				throw new Exception(__( 'Please make sure your card details have been entered correctly and that your browser supports JavaScript', $this->cfg['text_domain']));
 		
-			$order = wc_get_order($order_id);
-		
+			$order = wc_get_order($order_id);	
+
 			$charge = $this->charge_user($order, $token);
 			$this->log("Stripe charge created: " . print_r($charge, true));
 			$charge_id = $charge['id'];
@@ -294,6 +294,10 @@ class mg_Gateway_Stripe extends WC_Payment_Gateway {
 			'amount' => $amount,
 			'card' => $token,
 			'description' => sprintf(__('%s - Order %s', $this->cfg['text_domain']), esc_html(get_bloginfo('name')), $order->get_order_number()),
+			'metadata' => array(
+				'customer_email' => $order->billing_email,
+				'edit_order_url' => get_edit_post_link($order->id, ''),
+			),
 		));
 		
 		return $charge;

--- a/plugin.php
+++ b/plugin.php
@@ -77,7 +77,7 @@ class mg_wc_Stripe {
 	
 	public function set_test_locale($locale, $domain) {
 		if ($domain === $this->cfg['text_domain'])
-			$locale = 'it_IT';
+			$locale = get_locale();
 		
 		return $locale;
 	}


### PR DESCRIPTION
1. Included the order name/address fields in the stripe token create. WooCommerce should validate these fields so hopefully no need to validate in the plugin.
2. Changed the hard-coded 'it_IT' locale to WordPress's `get_locale()` function to correctly set translation language.
